### PR TITLE
Folder support and URL handling changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -106,6 +106,16 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
         // we don't have to modify how the cucumber plugin report generator's links
         String projectName = build.getParent().getFullName();
 
+        String thisBuildUrl = build.getUrl();
+        String previousBuildUrl = null;
+        if(build.getPreviousCompletedBuild() != null) {
+            previousBuildUrl = build.getPreviousCompletedBuild().getUrl();
+        }
+        String nextBuildUrl = null;
+        if(build.getNextBuild() != null) {
+             nextBuildUrl = build.getNextBuild().getUrl();
+        }
+
         if (Computer.currentComputer() instanceof SlaveComputer) {
             listener.getLogger().println("[CucumberReportPublisher] Copying all json files from slave: " + workspaceJsonReportDirectory.getRemote() + " to master reports directory: " + targetBuildDirectory);
         } else {
@@ -129,7 +139,9 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
                 Configuration configuration = new Configuration(targetBuildDirectory, projectName);
                 configuration.setStatusFlags(skippedFails, pendingFails, undefinedFails, missingFails);
                 configuration.setParallelTesting(parallelTesting);
-                configuration.setJenkinsBasePath(jenkinsBasePath);
+                configuration.setJenkinsBuildURL(thisBuildUrl);
+                configuration.setJenkinsPreviousBuildURL(previousBuildUrl);
+                configuration.setJenkinsNextBuildURL(nextBuildUrl);
                 configuration.setRunWithJenkins(true);
                 configuration.setBuildNumber(buildNumber);
 

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.groovy
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.groovy
@@ -13,11 +13,6 @@ f.advanced(field:"help") {
     f.entry(title:_("fileExcludePattern.name"), description:_("fileExcludePattern.description"), field:"fileExcludePattern") {
         f.textbox()
     }
-
-    f.entry(title:_("jenkinsBasePath.name"), description:_("jenkinsBasePath.description"), field:"jenkinsBasePath") {
-        f.textbox()
-    }
-
     f.entry(title:_("skippedFails.name"), description:_("skippedFails.description"), field:"skippedFails") {
         f.checkbox()
     }

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
@@ -5,9 +5,6 @@ fileIncludePattern.description=Default include pattern is '**/*.json'.
 fileExcludePattern.name=File Exclude Pattern
 fileExcludePattern.description=Nothing is excluded by default.
 
-jenkinsBasePath.name=Jenkins Base Path
-jenkinsBasePath.description=The path to the Jenkins user content url e.g. http://host:port[/jenkins/]plugin - leave empty if Jenkins url root is host:port.
-
 skippedFails.name=Skipped steps fails the Build
 skippedFails.description=Tick this if you want skipped steps to cause the build to fail.
 pendingFails.name=Pending steps fails the Build


### PR DESCRIPTION
Changes to add folder support (#62) as well as delegate URL generation to Jenkins; supports situations where the build numbers aren't continuous (Set Build Number plugin will do this)

In the process removes the jenkinsBasePath property as it is no longer used.