### PR TITLE
Read and combine all identically named features into one json report …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,5 +101,11 @@
             <artifactId>cucumber-reporting</artifactId>
             <version>3.2.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>3.0.1</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/After.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/After.java
@@ -1,0 +1,120 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "result",
+        "match"
+})
+public class After {
+
+    @JsonProperty("result")
+    private Result result;
+    @JsonProperty("match")
+    private Match match;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The result
+     */
+    @JsonProperty("result")
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     *
+     * @param result
+     * The result
+     */
+    @JsonProperty("result")
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @return
+     * The match
+     */
+    @JsonProperty("match")
+    public Match getMatch() {
+        return match;
+    }
+
+    /**
+     *
+     * @param match
+     * The match
+     */
+    @JsonProperty("match")
+    public void setMatch(Match match) {
+        this.match = match;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Generated("org.jsonschema2pojo")
+    @JsonPropertyOrder({
+            "location"
+    })
+    public static class Match_ {
+
+        @JsonProperty("location")
+        private String location;
+        @JsonIgnore
+        private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+        /**
+         *
+         * @return
+         * The location
+         */
+        @JsonProperty("location")
+        public String getLocation() {
+            return location;
+        }
+
+        /**
+         *
+         * @param location
+         * The location
+         */
+        @JsonProperty("location")
+        public void setLocation(String location) {
+            this.location = location;
+        }
+
+        @JsonAnyGetter
+        public Map<String, Object> getAdditionalProperties() {
+            return this.additionalProperties;
+        }
+
+        @JsonAnySetter
+        public void setAdditionalProperty(String name, Object value) {
+            this.additionalProperties.put(name, value);
+        }
+
+    }
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Before.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Before.java
@@ -1,0 +1,77 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "result",
+        "match"
+})
+public class Before {
+
+    @JsonProperty("result")
+    private Result result;
+    @JsonProperty("match")
+    private After.Match_ match;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The result
+     */
+    @JsonProperty("result")
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     *
+     * @param result
+     * The result
+     */
+    @JsonProperty("result")
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @return
+     * The match
+     */
+    @JsonProperty("match")
+    public After.Match_ getMatch() {
+        return match;
+    }
+
+    /**
+     *
+     * @param match
+     * The match
+     */
+    @JsonProperty("match")
+    public void setMatch(After.Match_ match) {
+        this.match = match;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Comment.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Comment.java
@@ -1,0 +1,77 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "line",
+        "value"
+})
+public class Comment {
+
+    @JsonProperty("line")
+    private Integer line;
+    @JsonProperty("value")
+    private String value;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The line
+     */
+    @JsonProperty("line")
+    public Integer getLine() {
+        return line;
+    }
+
+    /**
+     *
+     * @param line
+     * The line
+     */
+    @JsonProperty("line")
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    /**
+     *
+     * @return
+     * The value
+     */
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     *
+     * @param value
+     * The value
+     */
+    @JsonProperty("value")
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/CucumberReport.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/CucumberReport.java
@@ -1,0 +1,164 @@
+
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "line",
+        "elements",
+        "name",
+        "description",
+        "id",
+        "keyword",
+        "uri"
+})
+public class CucumberReport {
+
+    @JsonProperty("line")
+    private Integer line;
+    @JsonProperty("elements")
+    private List<Element> elements = new ArrayList<Element>();
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("keyword")
+    private String keyword;
+    @JsonProperty("uri")
+    private String uri;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * @return The line
+     */
+    @JsonProperty("line")
+    public Integer getLine() {
+        return line;
+    }
+
+    /**
+     * @param line The line
+     */
+    @JsonProperty("line")
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    /**
+     * @return The elements
+     */
+    @JsonProperty("elements")
+    public List<Element> getElements() {
+        return elements;
+    }
+
+    /**
+     * @param elements The elements
+     */
+    @JsonProperty("elements")
+    public void setElements(List<Element> elements) {
+        this.elements = elements;
+    }
+
+    /**
+     * @return The name
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name The name
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return The description
+     */
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @param description The description
+     */
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     * @return The id
+     */
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @param id The id
+     */
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return The keyword
+     */
+    @JsonProperty("keyword")
+    public String getKeyword() {
+        return keyword;
+    }
+
+    /**
+     * @param keyword The keyword
+     */
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    /**
+     * @return The uri
+     */
+    @JsonProperty("uri")
+    public String getUri() {
+        return uri;
+    }
+
+    /**
+     * @param uri The uri
+     */
+    @JsonProperty("uri")
+    public void setUri(String uri) {
+        this.uri = uri;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Element.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Element.java
@@ -1,0 +1,263 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "line",
+        "name",
+        "description",
+        "type",
+        "keyword",
+        "steps",
+        "before",
+        "id",
+        "after",
+        "tags"
+})
+public class Element {
+
+    @JsonProperty("line")
+    private Integer line;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("type")
+    private String type;
+    @JsonProperty("keyword")
+    private String keyword;
+    @JsonProperty("steps")
+    private List<Step> steps = new ArrayList<Step>();
+    @JsonProperty("before")
+    private List<Before> before = new ArrayList<Before>();
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("after")
+    private List<After> after = new ArrayList<After>();
+    @JsonProperty("tags")
+    private List<Tag> tags = new ArrayList<Tag>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The line
+     */
+    @JsonProperty("line")
+    public Integer getLine() {
+        return line;
+    }
+
+    /**
+     *
+     * @param line
+     * The line
+     */
+    @JsonProperty("line")
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    /**
+     *
+     * @return
+     * The name
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * @param name
+     * The name
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     * @return
+     * The description
+     */
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     *
+     * @param description
+     * The description
+     */
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /**
+     *
+     * @return
+     * The type
+     */
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     *
+     * @param type
+     * The type
+     */
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     *
+     * @return
+     * The keyword
+     */
+    @JsonProperty("keyword")
+    public String getKeyword() {
+        return keyword;
+    }
+
+    /**
+     *
+     * @param keyword
+     * The keyword
+     */
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    /**
+     *
+     * @return
+     * The steps
+     */
+    @JsonProperty("steps")
+    public List<Step> getSteps() {
+        return steps;
+    }
+
+    /**
+     *
+     * @param steps
+     * The steps
+     */
+    @JsonProperty("steps")
+    public void setSteps(List<Step> steps) {
+        this.steps = steps;
+    }
+
+    /**
+     *
+     * @return
+     * The before
+     */
+    @JsonProperty("before")
+    public List<Before> getBefore() {
+        return before;
+    }
+
+    /**
+     *
+     * @param before
+     * The before
+     */
+    @JsonProperty("before")
+    public void setBefore(List<Before> before) {
+        this.before = before;
+    }
+
+    /**
+     *
+     * @return
+     * The id
+     */
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    /**
+     *
+     * @param id
+     * The id
+     */
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    /**
+     *
+     * @return
+     * The after
+     */
+    @JsonProperty("after")
+    public List<After> getAfter() {
+        return after;
+    }
+
+    /**
+     *
+     * @param after
+     * The after
+     */
+    @JsonProperty("after")
+    public void setAfter(List<After> after) {
+        this.after = after;
+    }
+
+    /**
+     *
+     * @return
+     * The tags
+     */
+    @JsonProperty("tags")
+    public List<Tag> getTags() {
+        return tags;
+    }
+
+    /**
+     *
+     * @param tags
+     * The tags
+     */
+    @JsonProperty("tags")
+    public void setTags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Match.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Match.java
@@ -1,0 +1,54 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "location"
+})
+public class Match {
+
+    @JsonProperty("location")
+    private String location;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The location
+     */
+    @JsonProperty("location")
+    public String getLocation() {
+        return location;
+    }
+
+    /**
+     *
+     * @param location
+     * The location
+     */
+    @JsonProperty("location")
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Result.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Result.java
@@ -1,0 +1,77 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "duration",
+        "status"
+})
+public class Result {
+
+    @JsonProperty("duration")
+    private Long duration;
+    @JsonProperty("status")
+    private String status;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The duration
+     */
+    @JsonProperty("duration")
+    public Long getDuration() {
+        return duration;
+    }
+
+    /**
+     *
+     * @param duration
+     * The duration
+     */
+    @JsonProperty("duration")
+    public void setDuration(Long duration) {
+        this.duration = duration;
+    }
+
+    /**
+     *
+     * @return
+     * The status
+     */
+    @JsonProperty("status")
+    public String getStatus() {
+        return status;
+    }
+
+    /**
+     *
+     * @param status
+     * The status
+     */
+    @JsonProperty("status")
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Step.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Step.java
@@ -1,0 +1,194 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "result",
+        "line",
+        "name",
+        "match",
+        "keyword",
+        "matchedColumns",
+        "comments"
+})
+public class Step {
+
+    @JsonProperty("result")
+    private Result result;
+    @JsonProperty("line")
+    private Integer line;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("match")
+    private Match match;
+    @JsonProperty("keyword")
+    private String keyword;
+    @JsonProperty("matchedColumns")
+    private List<Integer> matchedColumns = new ArrayList<Integer>();
+    @JsonProperty("comments")
+    private List<Comment> comments = new ArrayList<Comment>();
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The result
+     */
+    @JsonProperty("result")
+    public Result getResult() {
+        return result;
+    }
+
+    /**
+     *
+     * @param result
+     * The result
+     */
+    @JsonProperty("result")
+    public void setResult(Result result) {
+        this.result = result;
+    }
+
+    /**
+     *
+     * @return
+     * The line
+     */
+    @JsonProperty("line")
+    public Integer getLine() {
+        return line;
+    }
+
+    /**
+     *
+     * @param line
+     * The line
+     */
+    @JsonProperty("line")
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    /**
+     *
+     * @return
+     * The name
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * @param name
+     * The name
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     *
+     * @return
+     * The match
+     */
+    @JsonProperty("match")
+    public Match getMatch() {
+        return match;
+    }
+
+    /**
+     *
+     * @param match
+     * The match
+     */
+    @JsonProperty("match")
+    public void setMatch(Match match) {
+        this.match = match;
+    }
+
+    /**
+     *
+     * @return
+     * The keyword
+     */
+    @JsonProperty("keyword")
+    public String getKeyword() {
+        return keyword;
+    }
+
+    /**
+     *
+     * @param keyword
+     * The keyword
+     */
+    @JsonProperty("keyword")
+    public void setKeyword(String keyword) {
+        this.keyword = keyword;
+    }
+
+    /**
+     *
+     * @return
+     * The matchedColumns
+     */
+    @JsonProperty("matchedColumns")
+    public List<Integer> getMatchedColumns() {
+        return matchedColumns;
+    }
+
+    /**
+     *
+     * @param matchedColumns
+     * The matchedColumns
+     */
+    @JsonProperty("matchedColumns")
+    public void setMatchedColumns(List<Integer> matchedColumns) {
+        this.matchedColumns = matchedColumns;
+    }
+
+    /**
+     *
+     * @return
+     * The comments
+     */
+    @JsonProperty("comments")
+    public List<Comment> getComments() {
+        return comments;
+    }
+
+    /**
+     *
+     * @param comments
+     * The comments
+     */
+    @JsonProperty("comments")
+    public void setComments(List<Comment> comments) {
+        this.comments = comments;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}

--- a/src/main/java/net/masterthought/jenkins/CucumberReportObject/Tag.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportObject/Tag.java
@@ -1,0 +1,77 @@
+package net.masterthought.jenkins.CucumberReportObject;
+
+import com.fasterxml.jackson.annotation.*;
+
+import javax.annotation.Generated;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by steve.jensen on 11/12/16.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({
+        "line",
+        "name"
+})
+public class Tag {
+
+    @JsonProperty("line")
+    private Integer line;
+    @JsonProperty("name")
+    private String name;
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     * The line
+     */
+    @JsonProperty("line")
+    public Integer getLine() {
+        return line;
+    }
+
+    /**
+     *
+     * @param line
+     * The line
+     */
+    @JsonProperty("line")
+    public void setLine(Integer line) {
+        this.line = line;
+    }
+
+    /**
+     *
+     * @return
+     * The name
+     */
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    /**
+     *
+     * @param name
+     * The name
+     */
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+}


### PR DESCRIPTION
This is written under the assumption that a configuration option will be written to support setting `combineIdenticallyNamedFeatures` to `true`/`false`.

Also, everything in `CucumberReportObject` are java objects required to deserialize the json reports to java objects (Maybe this is already done elsewhere, but I couldn't tell). 

This implementation basically deserializes all the report files that have been generated from the run to java objects, inspects the feature names and combines all `Element` (`scenario`) objects where feature name is identical into a single `CucumberReport` object per feature. After which, I serialize the CucumberReport object to a single json report per Feature.

Not familiar with adding jenkins configuration options but thought I'd make an attempt to get my implementation shared. I currently just run this as an additional script after my tests, but I think it would be better to be available in this plugin.

Relates to https://github.com/damianszczepanik/cucumber-reporting/issues/504