### PR TITLE
PR for issue 118 - Requesting help in using the new Classifications programatically

### DIFF
--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -250,9 +250,6 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
         } catch (MacroEvaluationException e) {
             log(listener, String.format("Could not evaluate macro '%s': %s", value, e.getMessage()));
             return value;
-        } catch (ClassCastException e) {
-            log(listener, String.format("ClassCastException '%s': %s", value, e.getMessage()));
-            return value;
         }
     }
 


### PR DESCRIPTION
This PR contains the following changes:

1. Made class Classification implement the "Serializable" interfact. 
2. When evaluating the macro for Tokens, if we get a ClassCastException, just use the "value". 
3. Fixed a typo in method name - 'evaluaeMacro' 

Also - 
1. This works with Jenkins project type - Pipeline
2. It is backwards compatible (with standalone type jobs)

Will update the issue #118 with details on how I am now invoking this plugin and adding classifications dynamically.