### PR TITLE
Pipeline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,31 @@ And you can drill down into tag specific reports:
 
 ![Tag report](https://github.com/damianszczepanik/cucumber-reporting/raw/master/.README/tag-report.png)
 
+### Pipeline usage
+
+```groovy
+ pipeline {
+     
+    agent any
+
+    stages {
+        stage('Build') {
+            steps {
+                //run your build
+                sh 'mvn clean verify'
+            }
+            post {
+                always {
+                    //generate cucumber reports
+                    cucumber '**/*.json'
+                }
+            }
+        }
+    }
+}
+
+```
+
 ## Advanced Configuration Options
 
 There are 4 advanced configuration options that can affect the outcome of the build status. Click on the Advanced tab in the configuration screen:

--- a/pom.xml
+++ b/pom.xml
@@ -111,5 +111,10 @@
             <artifactId>commons-collections4</artifactId>
             <version>4.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.8</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Fixes #81 

This PR includes support for using this plugin in workflow jobs/pipelines.
The main needed change was refactoring of the actions. Using a `TransientActionFactory` makes sure that the action is only added once to a `Run`, no matter how many times the report step is run.
Actions have also been moved to a separate package, with old implementations marked as `@Deprecated`, so that old reports continue to work.

For a better user experience in pipeline scripts, the symbolic name `cucumber` was used for this plugin (analogous to the `junit` step from the JUnit plugin). 
Also most parameters have been marked as optional, since there are already sensible defaults set.
The only required parameter is `fileIncludePattern`.

Example usage:
```groovy
node('master') {
    try {
        //run some cucumber tests
        sh 'mvn clean install'
    } finally {
        //generate cucumber html report
        cucumber '**/cucumber-*.json'
    }
}
```

Current limitation is, that includes and excludes are only evaluated **after** the .json files are already copied to the cache directory. So if you call the step multiple times, only the includes and excludes of the very last invocation count.

A similar limitation is in effect for most other settings, as each invocation will generate a wholly new report.