### PR TITLE
Patch for #215: [Feature Request] Link to latest result in side panel of pipeline job

### DIFF
--- a/src/main/java/net/masterthought/jenkins/CucumberReportProjectAction.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportProjectAction.java
@@ -1,16 +1,15 @@
 package net.masterthought.jenkins;
 
-import hudson.model.AbstractProject;
+import hudson.model.Job;
 import hudson.model.ProminentProjectAction;
 import hudson.model.Run;
-
 import net.masterthought.cucumber.ReportBuilder;
 
 public class CucumberReportProjectAction extends CucumberReportBaseAction implements ProminentProjectAction {
 
-    private final AbstractProject<?, ?> project;
+    private final Job<?, ?> project;
 
-    public CucumberReportProjectAction(AbstractProject<?, ?> project) {
+    public CucumberReportProjectAction(Job<?, ?> project) {
         this.project = project;
     }
 

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -421,11 +421,6 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
         return BuildStepMonitor.NONE;
     }
 
-    @Override
-    public Action getProjectAction(AbstractProject<?, ?> project) {
-        return new CucumberReportProjectAction(project);
-    }
-
     public static class Classification extends AbstractDescribableImpl<Classification> implements Serializable {
 
         public String key;

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -228,7 +228,7 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
 
         generateReport(run, workspace, listener);
 
-        SafeArchiveServingRunAction caa = new SafeArchiveServingRunAction(new File(run.getRootDir(), ReportBuilder.BASE_DIRECTORY),
+        SafeArchiveServingRunAction caa = new SafeArchiveServingRunAction(run, new File(run.getRootDir(), ReportBuilder.BASE_DIRECTORY),
                 ReportBuilder.BASE_DIRECTORY, ReportBuilder.HOME_PAGE, CucumberReportBaseAction.ICON_NAME, Messages.SidePanel_DisplayName());
         run.replaceAction(caa);
     }


### PR DESCRIPTION
Patch for  https://github.com/jenkinsci/cucumber-reports-plugin/issues/215

These are the changes to add a link to tje cucumber report of the latest build to the side panel of (multibranch) pipeline jobs. I basically applied the instructions given in https://jenkins.io/blog/2016/05/25/update-plugin-for-pipeline/.

I tested this in a branch based on tag "cucumber-reports-3.14.0" on a Jenkins 2.100+ in free-style and pipeline jobs (both simple and multibranch).