### PR TITLE
add parameter to disable trends. In our project single jenkins job is…

### DIFF
--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -56,6 +56,7 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
     private String buildStatus;
 
     private int trendsLimit;
+    private boolean trendsDisabled;
     private boolean parallelTesting;
     private String sortingMethod = SortingMethod.NATURAL.name();
     private List<Classification> classifications = Collections.emptyList();
@@ -112,6 +113,15 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
     @DataBoundSetter
     public void setTrendsLimit(int trendsLimit) {
         this.trendsLimit = trendsLimit;
+    }
+
+    public boolean isTrendsDisabled() {
+        return trendsDisabled;
+    }
+
+    @DataBoundSetter
+    public void setTrendsDisabled(boolean trendsDisabled) {
+        this.trendsDisabled = trendsDisabled;
     }
 
     public String getFileExcludePattern() {
@@ -283,7 +293,11 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
         configuration.setParallelTesting(parallelTesting);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber(buildNumber);
-        configuration.setTrends(new File(trendsDir, TRENDS_FILE), trendsLimit);
+        if (isTrendsDisabled()) {
+            configuration.setTrendsStatsFile(null);
+        } else {
+            configuration.setTrends(new File(trendsDir, TRENDS_FILE), trendsLimit);
+        }
         // null checker because of the regression in 3.10.2
         configuration.setSortingMethod(sortingMethod == null ? SortingMethod.NATURAL : SortingMethod.valueOf(sortingMethod));
 

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
@@ -33,6 +33,12 @@
                     description="${%trendsLimit.description}">
                 <f:textbox default="0"/>
             </f:entry>
+            <f:entry
+                    title="${%trendsDisabled.title}"
+                    field="trendsDisabled"
+                    description="${%trendsDisabled.description}">
+                <f:checkbox/>
+            </f:entry>
         </f:section>
 
 

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
@@ -9,6 +9,8 @@ fileExcludePattern.title=File Exclude Pattern
 fileExcludePattern.description=Filter for the files that should be excluded from the report.
 trendsLimit.title=Limit for trends
 trendsLimit.description=Number of past reports that should be presented. Zero means unlimited number of builds.
+trendsDisabled.title=Disable trends
+trendsDisabled.description=Disable trends when they are useless (ex. same test job is used for different test packs) or to save time and resources
 # ===
 buildResult=Build Result
 buildResult.description=This section allows to configure when the build is marked as failed or unstable. Result is changed when at least one of below rule is true.


### PR DESCRIPTION
… used to run multiple test packs in parallel and trends file becomes corrupted in a week. We have to cleanup. And trends themselves are useless in this kind of jobs