### PR TITLE
trendsLimit = -1 to disable trends.

### DIFF
--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -283,7 +283,12 @@ public class CucumberReportPublisher extends Publisher implements SimpleBuildSte
         configuration.setParallelTesting(parallelTesting);
         configuration.setRunWithJenkins(true);
         configuration.setBuildNumber(buildNumber);
-        configuration.setTrends(new File(trendsDir, TRENDS_FILE), trendsLimit);
+        // disable trends
+        if (trendsLimit == -1) {
+            configuration.setTrendsStatsFile(null);
+        } else {
+            configuration.setTrends(new File(trendsDir, TRENDS_FILE), trendsLimit);
+        }
         // null checker because of the regression in 3.10.2
         configuration.setSortingMethod(sortingMethod == null ? SortingMethod.NATURAL : SortingMethod.valueOf(sortingMethod));
 

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
@@ -8,7 +8,7 @@ classificationsFilePattern.description=Pattern used to locate classification (pr
 fileExcludePattern.title=File Exclude Pattern
 fileExcludePattern.description=Filter for the files that should be excluded from the report.
 trendsLimit.title=Limit for trends
-trendsLimit.description=Number of past reports that should be presented. Zero means unlimited number of builds.
+trendsLimit.description=Number of past reports that should be presented. Zero means unlimited number of builds. Minus one (-1) disables trends
 # ===
 buildResult=Build Result
 buildResult.description=This section allows to configure when the build is marked as failed or unstable. Result is changed when at least one of below rule is true.


### PR DESCRIPTION
 In our project single jenkins job is used to run multiple test packs in parallel and trends file becomes corrupted in a week. We have to cleanup. And trends themselves are useless in this kind of jobs