### PR TITLE
Bump cucumber-reporting version to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
         <dependency>
             <groupId>net.masterthought</groupId>
             <artifactId>cucumber-reporting</artifactId>
-            <version>4.9.0</version>
+            <version>4.10.0</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Bump cucumber-reporting version so reports in Jenkins can use https://github.com/damianszczepanik/cucumber-reporting/pull/870 feature.