### PR TITLE
fix(CucumberReportPublisher):setNotFailingStatuses for jenkins in CucumberReportPublisher

### DIFF
--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
@@ -104,7 +104,11 @@
                     field="failedFeaturesPercentage">
                 <f:textbox default="0"/>
             </f:entry>
-
+            <f:entry
+                    title="${%notFailingStatues.title}"
+                    field="notFailingStatues">
+                <f:repeatableProperty field="notFailingStatues"/>
+            </f:entry>
 
             <f:entry
                     title="${%buildStatus.title}"

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
@@ -22,6 +22,7 @@ pendingStepsPercentage.title=Percentage of pending steps
 undefinedStepsPercentage.title=Percentage of undefined steps
 failedScenariosPercentage.title=Percentage of failed scenarios
 failedFeaturesPercentage.title=Percentage of failed features
+notFailingStatues.title=Statues that should not fail the scenario
 # ===
 buildStatus.title=Build Status
 buildStatus.description=Build result to which the build should be set when the report becomes failed or unstable.

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/help-setNotFailingStatues.html
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/help-setNotFailingStatues.html
@@ -1,0 +1,3 @@
+<p>Set statues that should not fail the status of the report.
+    def setNotFailingStatues = ["SKIPPED"....] as Set
+    notFailingStatues: setNotFailingStatues </p>


### PR DESCRIPTION
1: adding the set not failing statuses to this class so that we can set this feature from jenkins like for other features we do mergeFeaturesWithRetest: true,
sortingMethod: 'ALPHABETICAL' in the jenkins

2: this is how we will use it through jenkins

def s = ["SKIPPED"] as Set
always {
cucumber fileIncludePattern: "${env.BUILD_NUMBER}/build/cucumber/bbt_*.json",
reportTitle: "${params.title}${env.TEST_ENVIRONMENT}/${params.cucumber_tag}",
notFailingStatues: s
}