### PR TITLE
Modernize to Jenkins 2.375.4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,2 +1,5 @@
-
-buildPlugin()
+buildPlugin(useContainerAgent: true, configurations: [
+  [ platform: 'linux', jdk: '11' ],
+  [ platform: 'windows', jdk: '11' ],
+  [ platform: 'linux', jdk: '17' ],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.51</version>
+        <version>4.71</version>
         <relativePath/>
     </parent>
 
@@ -16,8 +16,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.346.x</artifactId>
-                <version>1763.v092b_8980a_f5e</version>
+                <artifactId>bom-2.375.x</artifactId>
+                <version>2198.v39c76fc308ca</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -29,7 +29,7 @@
 
     <!-- some comments here: https://jenkins.io/doc/developer/plugin-development/dependency-management/ -->
     <properties>
-        <jenkins.version>2.346.3</jenkins.version>
+        <jenkins.version>2.375.4</jenkins.version>
 
         <slf4jVersion>1.7.30</slf4jVersion>
     </properties>
@@ -117,11 +117,6 @@
 
     <dependencies>
         <!-- to satisfy dependencies problem with different versions -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>${slf4jVersion}</version>
-        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/src/main/java/net/masterthought/jenkins/CucumberReportBaseAction.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportBaseAction.java
@@ -1,7 +1,6 @@
 package net.masterthought.jenkins;
 
 import hudson.model.Action;
-
 import net.masterthought.cucumber.ReportBuilder;
 
 public abstract class CucumberReportBaseAction implements Action {

--- a/src/main/java/net/masterthought/jenkins/CucumberReportDescriptor.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportDescriptor.java
@@ -6,9 +6,8 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Publisher;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-import org.kohsuke.stapler.QueryParameter;
-
 import net.masterthought.cucumber.sorting.SortingMethod;
+import org.kohsuke.stapler.QueryParameter;
 
 public class CucumberReportDescriptor extends BuildStepDescriptor<Publisher> {
 

--- a/src/main/java/net/masterthought/jenkins/CucumberReportProjectAction.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportProjectAction.java
@@ -3,7 +3,6 @@ package net.masterthought.jenkins;
 import hudson.model.Job;
 import hudson.model.ProminentProjectAction;
 import hudson.model.Run;
-
 import net.masterthought.cucumber.ReportBuilder;
 
 public class CucumberReportProjectAction extends CucumberReportBaseAction implements ProminentProjectAction {

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
 import hudson.FilePath;
@@ -23,7 +24,6 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Recorder;
-import javax.annotation.Nonnull;
 import jenkins.tasks.SimpleBuildStep;
 import net.masterthought.cucumber.Configuration;
 import net.masterthought.cucumber.ReportBuilder;
@@ -426,7 +426,7 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
     }
 
     @Override
-    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath workspace, @Nonnull Launcher launcher, @Nonnull TaskListener listener)
+    public void perform(@NonNull Run<?, ?> run, @NonNull FilePath workspace, @NonNull Launcher launcher, @NonNull TaskListener listener)
             throws InterruptedException, IOException {
 
         keepBackwardCompatibility();

--- a/src/main/java/net/masterthought/jenkins/SafeArchiveServingAction.java
+++ b/src/main/java/net/masterthought/jenkins/SafeArchiveServingAction.java
@@ -13,15 +13,15 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.servlet.ServletException;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.FilePath;
 import hudson.Util;
 import hudson.model.Action;
 import hudson.model.DirectoryBrowserSupport;
 import hudson.util.HttpResponses;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.servlet.ServletException;
 import org.apache.commons.collections4.CollectionUtils;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.StaplerRequest;
@@ -110,7 +110,7 @@ public class SafeArchiveServingAction implements Action {
         return fileChecksums.get(file);
     }
 
-    private String calculateChecksum(@Nonnull File file) throws NoSuchAlgorithmException, IOException {
+    private String calculateChecksum(@NonNull File file) throws NoSuchAlgorithmException, IOException {
         MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
         try (FileInputStream fis = new FileInputStream(file)) {
             byte[] bytes = new byte[1024];
@@ -121,7 +121,7 @@ public class SafeArchiveServingAction implements Action {
         return Util.toHexString(sha1.digest());
     }
 
-    private void processDirectory(@Nonnull File directory, @Nullable String path) throws NoSuchAlgorithmException, IOException {
+    private void processDirectory(@NonNull File directory, @Nullable String path) throws NoSuchAlgorithmException, IOException {
         if (LOGGER.isLoggable(Level.FINER)) {
             LOGGER.log(Level.FINER, "Scanning " + getRootDir());
         }

--- a/src/main/java/net/masterthought/jenkins/SafeArchiveServingRunAction.java
+++ b/src/main/java/net/masterthought/jenkins/SafeArchiveServingRunAction.java
@@ -8,9 +8,9 @@ import java.util.Collections;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.model.Action;
 import hudson.model.Run;
-import javax.annotation.Nonnull;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 
@@ -25,7 +25,7 @@ public class SafeArchiveServingRunAction extends SafeArchiveServingAction implem
     private Run<?, ?> run;
     private String directorySuffix;
 
-	public SafeArchiveServingRunAction(@Nonnull Run<?, ?> r, File rootDir, String urlName, String indexFile, String iconName, String title, String directorySuffix, String... safeExtensions) {
+	public SafeArchiveServingRunAction(@NonNull Run<?, ?> r, File rootDir, String urlName, String indexFile, String iconName, String title, String directorySuffix, String... safeExtensions) {
         super(rootDir, urlName, indexFile, iconName, title, safeExtensions);
         this.directorySuffix = directorySuffix;
 		this.run = r;


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling, build on Java 11/17, and move this plugin to the [recommended](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) Jenkins baseline version. It also migrates from `javax.annotations` to SpotBugs as mentioned in the [Improve a Plugin docs](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/).

It was tested by running `mvn clean verify`.

Use this link to re-run the recipe: https://app.moderne.io/recipes/builder/w2GnS