### PR TITLE
Added maximum string length constraint. (#449)

### DIFF
--- a/src/main/java/net/masterthought/jenkins/CucumberReportDescriptor.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportDescriptor.java
@@ -35,6 +35,10 @@ public class CucumberReportDescriptor extends BuildStepDescriptor<Publisher> {
         return isValidInteger(value);
     }
 
+    public FormValidation doMaxStringLengthConstraint(@QueryParameter String value) {
+        return isValidInteger(value);
+    }
+
     public FormValidation doCheckFailedStepsNumber(@QueryParameter String value) {
         return isValidInteger(value);
     }

--- a/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
+++ b/src/main/java/net/masterthought/jenkins/CucumberReportPublisher.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.AbortException;
 import hudson.Extension;
@@ -78,6 +79,7 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
     private boolean undefinedAsNotFailingStatus;
 
     private int trendsLimit;
+    private int maxStringLengthConstraint = 20_000_000;
     private String sortingMethod;
     private List<Classification> classifications;
     private String customJsFiles;
@@ -156,6 +158,15 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
     @DataBoundSetter
     public void setTrendsLimit(int trendsLimit) {
         this.trendsLimit = trendsLimit;
+    }
+
+    public int getMaxStringLengthConstraint() {
+        return maxStringLengthConstraint;
+    }
+
+    @DataBoundSetter
+    public void setMaxStringLengthConstraint(int maxStringLengthConstraint) {
+        this.maxStringLengthConstraint = maxStringLengthConstraint;
     }
 
     public String getFileExcludePattern() {
@@ -558,6 +569,8 @@ public class CucumberReportPublisher extends Recorder implements SimpleBuildStep
         }
 
         setFailingStatuses(configuration);
+
+        StreamReadConstraints.overrideDefaultStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(maxStringLengthConstraint).build());
 
         ReportBuilder reportBuilder = new ReportBuilder(jsonFilesToProcess, configuration);
         Reportable result = reportBuilder.generateReports();

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.jelly
@@ -33,6 +33,11 @@
                     field="trendsLimit">
                 <f:textbox default="0"/>
             </f:entry>
+            <f:entry
+                    title="${%maxStringLengthConstraint.title}"
+                    field="maxStringLengthConstraint">
+                <f:textbox default="20000000"/>
+            </f:entry>
         </f:section>
 
 

--- a/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
+++ b/src/main/resources/net/masterthought/jenkins/CucumberReportPublisher/config.properties
@@ -6,6 +6,7 @@ fileIncludePattern.title=File Include Pattern
 classificationsFilePattern.title=Classifications File Pattern
 fileExcludePattern.title=File Exclude Pattern
 trendsLimit.title=Limit for trends
+maxStringLengthConstraint.title=Maximum string size (Stream read constraint of JacksonCore)
 # ===
 buildResult=Build Result
 buildResult.description=This section allows to configure when the build is marked as failed or unstable. Result is changed when any of below rule is enabled.


### PR DESCRIPTION
Adds maxStringLengthConstraint field to personalize the readStreamConstraints of JacksonCore. By default the maxStringLength of the StreamReadConstraint is 20_000_000, from what I understood if the json files surpass that size it will throw the error described in issue #449 .

### Testing done
I executed three builds with .json files from my tests.
1. Setting the maxStringLengthConstraint to 25_000_000.
2. Default plugin execution leaving the maxStringLengthConstraint default value of 20_000_000.
3. Limiting the maxStringLengthConstraint to 20. (Forcing to throw the same error as #449 )

Relevant links:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.15.2
https://github.com/FasterXML/jackson-core/issues/1014

Tests screenshots:
Test 1:
![Test-1](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/94b5b6fd-25e3-44c9-b4b3-4576cbad38e1)
![Test-1 (2)](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/6cbfde14-65c2-44a6-9d59-a843317e00f2)

Test 2:
![Test-2 (2)](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/15ee45db-a37a-4fec-95d3-9f15801cf9a1)
![Test-2](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/f7f2da45-80e8-4a52-8643-a98cbcfbbf86)

Test 3:
![Test-3 (2)](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/ef72ac06-dfd2-4ded-b0d0-e3fc1b2a02e7)
![Test-3](https://github.com/jenkinsci/cucumber-reports-plugin/assets/43856678/f37322ff-6e29-45be-9b4f-572eccabfbf6)


```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```