### PR TITLE
Explicitly declare dependencies and rely on plugins for libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,8 @@
         <revision>5.10.1</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/cucumber-reports-plugin</gitHubRepo>
+        <hpi.bundledArtifacts>commons-configuration2,cucumber-reporting,velocity-engine-core</hpi.bundledArtifacts>
+        <hpi.strictBundledArtifacts>true</hpi.strictBundledArtifacts>
         <jenkins.baseline>2.504</jenkins.baseline>
         <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     </properties>
@@ -131,6 +133,30 @@
             <artifactId>commons-collections4-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-lang3-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>commons-text-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>joda-time-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jsoup</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>antisamy-markup-formatter</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
         </dependency>
@@ -150,6 +176,10 @@
                 <exclusion>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.googlecode.owasp-java-html-sanitizer</groupId>
+                    <artifactId>owasp-java-html-sanitizer</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Explicitly declare dependencies and rely on plugins for libraries

Explicitly declare dependencies and rely on plugins for libraries

The cucumber-reporting dependency has transitive dependencies on:

* commons-lang3
* commons-text
* jackson2
* joda-time
* jsoup
* owasp-java-html-sanitizer

Rely on the Jenkins plugins that provide those libraries rather than bundling the libraries as transitive dependencies in the plugin hpi file.

Also updates the plugin to require Jenkins 2.504.3 or newer and to rely on the slf4j API library provided by Jenkins core rather than including the library in the plugin hpi file.

The [developer documentation](https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#build-time-validation-of-bundled-artifacts) provides more details.

Originally added to Maven hpi plugin in pull request:

* https://github.com/jenkinsci/maven-hpi-plugin/pull/771

### Testing done

* Confirmed that automated tests pass

### Testing to be done

* Interactively check the plugin is still well-behaved.  Pull request will remain draft until that testing is complete.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
