### PR TITLE
Fix checksum handling for partial reads

### DIFF
--- a/src/main/java/net/masterthought/jenkins/SafeArchiveServingAction.java
+++ b/src/main/java/net/masterthought/jenkins/SafeArchiveServingAction.java
@@ -147,12 +147,13 @@ public class SafeArchiveServingAction implements Action {
         }
     }
 
-    private String calculateChecksum(@NonNull File file) throws NoSuchAlgorithmException, IOException {
+    static String calculateChecksum(@NonNull File file) throws NoSuchAlgorithmException, IOException {
         MessageDigest sha1 = MessageDigest.getInstance("SHA-1");
         try (FileInputStream fis = new FileInputStream(file)) {
             byte[] bytes = new byte[1024];
-            while (-1 != (fis.read(bytes))) {
-                sha1.update(bytes);
+            int bytesRead;
+            while ((bytesRead = fis.read(bytes)) != -1) {
+                sha1.update(bytes, 0, bytesRead);
             }
         }
         return Util.toHexString(sha1.digest());

--- a/src/test/java/net/masterthought/jenkins/SafeArchiveServingActionTest.java
+++ b/src/test/java/net/masterthought/jenkins/SafeArchiveServingActionTest.java
@@ -1,0 +1,30 @@
+package net.masterthought.jenkins;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+
+import hudson.Util;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class SafeArchiveServingActionTest {
+
+    @TempDir
+    Path temporaryDirectory;
+
+    @Test
+    void calculatesChecksumForPartialFinalBuffer() throws Exception {
+        byte[] content = new byte[1025];
+        for (int i = 0; i < content.length; i++) {
+            content[i] = (byte) i;
+        }
+        Path file = Files.write(temporaryDirectory.resolve("report.html"), content);
+
+        String expected = Util.toHexString(MessageDigest.getInstance("SHA-1").digest(content));
+
+        assertEquals(expected, SafeArchiveServingAction.calculateChecksum(file.toFile()));
+    }
+}


### PR DESCRIPTION
Companion fix for #559, built on its exact head (f1dc486be856492ef99d4aad2b2e5e9279ef62a7).

The plugin-parent upgrade exposes NCR_NOT_PROPERLY_CHECKED_READ in SafeArchiveServingAction. This is a real checksum bug: the existing loop ignores FileInputStream.read's returned byte count and hashes the entire buffer, including stale bytes after a partial final read.

This change:
- hashes only the bytes actually returned by each read;
- makes the stateless helper package-visible for a focused test; and
- adds a regression test using a 1,025-byte file, where the final buffer is partial.

Verification:
- JDK 25: mvn -B -ntp -Dtest=SafeArchiveServingActionTest verify — BUILD SUCCESS; focused test, HPI packaging, enforcers, and SpotBugs passed
- mvn -B -ntp verify — BUILD SUCCESS in 6m29s; 11 tests, 0 failures/errors/skips; HPI packaging and Maven enforcers passed; SpotBugs 4.10.3.0 reported 0 bugs and 0 errors
- git diff --check

AI assistance disclosure: JAIPilot/Codex assisted with diagnosis and implementation. The complete diff was reviewed and the repository-native verification above was run locally.